### PR TITLE
Add server_name to the Truffle API (ADV-23138)

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -119,6 +119,11 @@ components:
           type: string
           example: This is a check note.
           nullable: true
+        server_name:
+          description: The name of the server who took the order.
+          type: string
+          example: John D
+          nullable: true
         order_type:
           $ref: '#/components/schemas/OrderType'
         order_sub_type:


### PR DESCRIPTION
Motivation
----------
Truffle would like to start displaying this on their KDS.

Modifications
-------------
Add the field.

https://centeredge.atlassian.net/browse/ADV-23138
