### PR TITLE
Update required and nullable properties (ADV-23613)

### DIFF
--- a/openapi/components/schemas/CreateMenu.yaml
+++ b/openapi/components/schemas/CreateMenu.yaml
@@ -3,7 +3,7 @@ properties:
   sub_category_name:
     description: Name of the sub-category.
     type: string
-    nullable: true
+    nullable: false
   category_name:
     description: Name of the category.
     type: string
@@ -11,7 +11,7 @@ properties:
   tax_name:
     description: Name of the tax.
     type: string
-    nullable: true
+    nullable: false
   menu_serving_name:
     description: "each"
     type: string
@@ -19,7 +19,7 @@ properties:
   kds_printer_name:
     description: Name of the KDS printer.
     type: string
-    nullable: true
+    nullable: false
   restaurant_id:
     description: ID of the restaurant.
     type: string
@@ -31,7 +31,7 @@ properties:
   include_tax:
     description: Indicates whether tax is included.
     type: string
-    nullable: true
+    nullable: false
   level:
     description: Will this item appear under Category or Sub Category
     type: string
@@ -47,7 +47,7 @@ properties:
   is_pizza:
     description: Indicates whether the menu item is a pizza.
     type: string
-    nullable: true
+    nullable: false
   price_type:
     description: always send as "fixed"
     type: string
@@ -55,18 +55,12 @@ properties:
   description:
     description: Description of the menu.
     type: string
-    nullable: true
+    nullable: false
   serving_size:
     description: Array of serving size objects with name, serving_price, serving_cost, and serving_discount.
     type: array
     nullable: false
 required:
-  - category_name
-  - menu_serving_name
   - restaurant_id
-  - menu_name
-  - level
-  - calories
   - center_edge
-  - price_type
-  - serving_size
+  - menu_name

--- a/openapi/components/schemas/CreateMenuCategory.yaml
+++ b/openapi/components/schemas/CreateMenuCategory.yaml
@@ -4,6 +4,10 @@ properties:
     description: The ID of the restaurant for which the menu category is being created.
     type: string
     nullable: false
+  center_edge:
+    description:
+    type: string
+    nullable: false
   category_name:
     description: The name of the menu category.
     type: string
@@ -11,11 +15,11 @@ properties:
   include_tax:
     description: Indicates whether tax is included in the category.
     type: string
-    nullable: true
+    nullable: false
   include_kitchen_printers:
     description: Indicates whether kitchen printers are included.
     type: string
-    nullable: true
+    nullable: false
   department_name:
     description: The name of the department.
     type: string
@@ -23,11 +27,11 @@ properties:
   tax_name:
     description: The name of the tax.
     type: string
-    nullable: true
+    nullable: false
   priority:
     description: The priority of the menu category.
     type: string
-    nullable: true
+    nullable: false
   serving_size_level:
     description: "each"
     type: string
@@ -35,9 +39,8 @@ properties:
   kds_printer_name:
     description: The name of the KDS printer.
     type: string
-    nullable: true
+    nullable: false
 required:
   - restaurant_id
+  - center_edge
   - category_name
-  - department_name
-  - serving_size_level

--- a/openapi/components/schemas/CreateMenuSubcategory.yaml
+++ b/openapi/components/schemas/CreateMenuSubcategory.yaml
@@ -7,7 +7,7 @@ properties:
   center_edge:
     description: The CenterEdge ID of the item.
     type: string
-    nullable: true
+    nullable: false
   category_name:
     description: The name of the category to which the sub-category belongs.
     type: string
@@ -15,7 +15,7 @@ properties:
   include_tax:
     description: Indicates whether tax is included.
     type: string
-    nullable: true
+    nullable: false
   sub_type_name:
     description: The name of the sub-category.
     type: string
@@ -23,7 +23,7 @@ properties:
   include_kitchen_printers:
     description: Indicates whether kitchen printers are included.
     type: string
-    nullable: true
+    nullable: false
   department_name:
     description: The name of the department.
     type: string
@@ -31,11 +31,11 @@ properties:
   tax_name:
     description: The name of the tax.
     type: string
-    nullable: true
+    nullable: false
   priority:
     description: The priority of the sub-category.
     type: string
-    nullable: true
+    nullable: false
   serving_size_level:
     description: "each"
     type: string
@@ -43,10 +43,8 @@ properties:
   kds_printer_name:
     description: The name of the kitchen display system printer.
     type: string
-    nullable: true
+    nullable: false
 required:
   - restaurant_id
+  - center_edge
   - category_name
-  - sub_type_name
-  - department_name
-  - serving_size_level

--- a/openapi/components/schemas/CreateModifier.yaml
+++ b/openapi/components/schemas/CreateModifier.yaml
@@ -11,9 +11,9 @@ properties:
   price:
     description: The price of the modifier.
     type: string
-    nullable: true
+    nullable: false
   center_edge:
-    description: The center edge of the modifier.
+    description: The center id edge of the modifier.
     type: string
     nullable: false
   enabledOnly:
@@ -26,7 +26,5 @@ properties:
     nullable: false
 required:
   - restaurant_id
-  - modifier_name
   - center_edge
-  - enabledOnly
-  - modifier_group
+  - modifier_name

--- a/openapi/components/schemas/CreateModifierGroup.yaml
+++ b/openapi/components/schemas/CreateModifierGroup.yaml
@@ -8,6 +8,10 @@ properties:
     description: The name of the modifier group.
     type: string
     nullable: false
+  center_edge:
+    description: The center id edge of the modifier.
+    type: string
+    nullable: false
   min:
     description: The minimum number of modifiers allowed.
     type: string
@@ -19,7 +23,7 @@ properties:
   free_modifier:
     description: how many modifiers can they get for free in this group
     type: string
-    nullable: true
+    nullable: false
   modifier_name:
     description: Comma seperated modifier names that belong in this group.
     type: string
@@ -27,6 +31,4 @@ properties:
 required:
   - restaurant_id
   - modifier_group_name
-  - min
-  - max
-  - modifier_name
+  - center_edge

--- a/openapi/components/schemas/CreateServingSize.yaml
+++ b/openapi/components/schemas/CreateServingSize.yaml
@@ -3,12 +3,15 @@ properties:
   restaurant_id:
     description: The ID of the restaurant.
     type: string
-    nullable: true
+    nullable: false
   serving_name:
     description: The name of the serving
     type: string
-    nullable: true
+    nullable: false
   description:
     description: Description of the serving.
     type: string
-    nullable: true
+    nullable: false
+required:
+  - restaurant_id
+  - serving_name

--- a/openapi/components/schemas/CreateTaxes.yaml
+++ b/openapi/components/schemas/CreateTaxes.yaml
@@ -3,35 +3,32 @@ properties:
   restaurant_id:
     description: The ID of the restaurant.
     type: string
-    nullable: true
+    nullable: false
   center_edge:
     description: The CenterEdge ID of the item.
     type: string
-    nullable: true
+    nullable: false
   tax_name:
     description: The name of the tax.
     type: string
-    nullable: true
+    nullable: false
   tax_type:
     description: The type of tax
     type: string
-    nullable: true
+    nullable: false
   apply_to:
     description: Always set to Item
     type: string
-    nullable: true
+    nullable: false
   tax_percentage:
     description: The percentage of the tax.
     type: string
-    nullable: true
+    nullable: false
   tax_code:
     description: The code for the tax.
     type: string
-    nullable: true
+    nullable: false
 required:
   - restaurant_id
+  - center_edge
   - tax_name
-  - tax_type
-  - apply_to
-  - tax_percentage
-  - tax_code

--- a/openapi/components/schemas/UpdateCategory.yaml
+++ b/openapi/components/schemas/UpdateCategory.yaml
@@ -11,7 +11,7 @@ properties:
   center_edge:
     description: 
     type: string
-    nullable: true
+    nullable: false
   category_id:
     description: The ID of the category.
     type: string
@@ -30,8 +30,5 @@ properties:
     nullable: false
 required:
   - restaurant_id
-  - restaurant_branch_id
+  - center_edge
   - category_id
-  - category_name
-  - kds_printer_name
-  - tax_name

--- a/openapi/components/schemas/UpdateMenu.yaml
+++ b/openapi/components/schemas/UpdateMenu.yaml
@@ -43,7 +43,7 @@ properties:
   center_edge:
     description: 
     type: string
-    nullable: true 
+    nullable: false 
   is_pizza:
     description: 
     type: string
@@ -62,17 +62,6 @@ properties:
     items:
       $ref: ./servingSize.yaml
 required:
-  - sub_category_name
-  - category_name
-  - tax_name
-  - menu_serving_name
-  - kds_printer_name
   - restaurant_id
   - menu_name
-  - include_tax
-  - level
-  - calories
-  - is_pizza
-  - price_type
-  - description
-  - serving_size
+  - center_edge

--- a/openapi/components/schemas/UpdateMenuSubcategory.yaml
+++ b/openapi/components/schemas/UpdateMenuSubcategory.yaml
@@ -11,7 +11,7 @@ properties:
   center_edge:
     description: 
     type: string
-    nullable: true
+    nullable: false
   sub_category_id:
     description: The ID of the subcategory.
     type: string
@@ -30,8 +30,5 @@ properties:
     nullable: false
 required:
   - restaurant_id
-  - restaurant_branch_id
+  - center_edge
   - sub_category_id
-  - sub_category_name
-  - kds_printer_name
-  - tax_name

--- a/openapi/components/schemas/UpdateModifier.yaml
+++ b/openapi/components/schemas/UpdateModifier.yaml
@@ -30,8 +30,5 @@ properties:
     nullable: false
 required:
   - restaurant_id
-  - restaurant_branch_id
-  - modifier_group
+  - center_edge
   - modifier_name
-  - price
-  - enabledOnly

--- a/openapi/components/schemas/UpdateModifierGroup.yaml
+++ b/openapi/components/schemas/UpdateModifierGroup.yaml
@@ -52,11 +52,5 @@ properties:
     nullable: false
 required:
   - restaurant_id
-  - restaurant_branch_id
-  - sub_category_id
+  - center_edge
   - modifier_group_name
-  - min
-  - max
-  - free_modifier
-  - kds_printer_name
-  - include_tax


### PR DESCRIPTION
Motivation
---
We want to update the isRequired and isNullable settings for the Add and Update schema object properties so that they will be excluded from the json output for non-critical fields.

Modifications
---
Updated the isRequired and isNullable settings for the Add and Update schema object properties so that only the most critical properties are required to have values, and the others will be excluded from the json output if they are null or empty.

https://centeredge.atlassian.net/browse/ADV-23613
