### PR TITLE
Change include prop data types to string (ADV-24652)

### DIFF
--- a/openapi/components/schemas/CreateMenuCategory.yaml
+++ b/openapi/components/schemas/CreateMenuCategory.yaml
@@ -14,12 +14,14 @@ properties:
     nullable: false
   include_tax:
     description: Indicates whether tax is included in the category.
-    type: boolean
+    type: string
     nullable: false
+    example: On
   include_kitchen_printers:
     description: Indicates whether kitchen printers are included.
-    type: boolean
+    type: string
     nullable: false
+    example: On
   department_name:
     description: The name of the department.
     type: string


### PR DESCRIPTION
Motivation
---
The include_tax and include_kitchen_printers data types should be strings> A value of ‘On’ is used in the examples in Postman. They are currently set as boolean values.

Modifications
---
Change data types to string.

https://centeredge.atlassian.net/browse/ADV-24652
