### PR TITLE
Add missing type specifier to CreateMenu property (ADV-23670)

### DIFF
--- a/openapi/components/schemas/CreateMenu.yaml
+++ b/openapi/components/schemas/CreateMenu.yaml
@@ -60,8 +60,8 @@ properties:
     description: Array of serving size objects with name, serving_price, serving_cost, and serving_discount.
     type: array
     nullable: false 
-  items: 
-    $ref: './ServingSize.yaml'
+    items: 
+      $ref: './ServingSize.yaml'
 required:
   - restaurant_id
   - center_edge


### PR DESCRIPTION
Motivation
---
The ServingSize property of the CreateMenu object in the TruffleApi is missing the item type specifier.

Modifications
---
Add missing type reference to ServingSize property of CreateMenu object.

https://centeredge.atlassian.net/browse/ADV-23670
