### PR TITLE
Change list request schema for category and subcategory (ADV-23683)

### DIFF
--- a/openapi/components/schemas/MenuCategoryList.yaml
+++ b/openapi/components/schemas/MenuCategoryList.yaml
@@ -1,3 +1,3 @@
 type: object
 allOf:
-  - $ref: ./MenuCategoryListItem.yaml
+  - $ref: ./ListRequest.yaml

--- a/openapi/components/schemas/MenuCategoryListItemBase.yaml
+++ b/openapi/components/schemas/MenuCategoryListItemBase.yaml
@@ -19,6 +19,10 @@ properties:
     type: array
     items:
       type: string
+  center_edge:
+    description: The CenterEdge id.
+    type: string
+    nullable: true
 required:
   - id
   - type_name

--- a/openapi/components/schemas/MenuSubcategoryList.yaml
+++ b/openapi/components/schemas/MenuSubcategoryList.yaml
@@ -1,3 +1,3 @@
 type: object
 allOf:
-  - $ref: ./MenuSubcategoryListItem.yaml
+  - $ref: ./ListRequest.yaml

--- a/openapi/components/schemas/ModifierGroupListItem.yaml
+++ b/openapi/components/schemas/ModifierGroupListItem.yaml
@@ -8,6 +8,10 @@ properties:
     description: The name of modifier group.
     type: string
     nullable: false
+  center_edge:
+    description: The CenterEdge id.
+    type: string
+    nullable: true
 required:
   - id
   - modifier_name     

--- a/openapi/components/schemas/ModifierListItem.yaml
+++ b/openapi/components/schemas/ModifierListItem.yaml
@@ -19,6 +19,10 @@ properties:
     type: array
     items:
       type: string
+  center_edge:
+    description: The CenterEdge id.
+    type: string
+    nullable: true
 required:
   - id
   - modifier_name


### PR DESCRIPTION
Motivation
---
- The category and subcategory list requests schemas reference incorrect schemas.
- Newly added 'center_edge' property needs to be added to list response schemas.

Modifications
---
- Changed category and subcategory list request schemas to reference correct ListRequest object.
- Added missing center_edge property to list response items.

https://centeredge.atlassian.net/browse/ADV-23683
