### PR TITLE
Make Truffle list response codes numeric in spec (ADV-23695)

### DIFF
--- a/openapi/components/schemas/MenuCategoryListResponse.yaml
+++ b/openapi/components/schemas/MenuCategoryListResponse.yaml
@@ -2,7 +2,8 @@ type: object
 properties:
   code:
     description: The status code of the response.
-    type: string
+    type: number
+    format: int32
     nullable: false
   data:
     description: The list of items.

--- a/openapi/components/schemas/MenuListResponse.yaml
+++ b/openapi/components/schemas/MenuListResponse.yaml
@@ -2,7 +2,8 @@ type: object
 properties:
   code:
     description: The status code of the response.
-    type: string
+    type: number
+    format: int32
     nullable: false
   data:
     description: The list of items.

--- a/openapi/components/schemas/MenuSubcategoryListResponse.yaml
+++ b/openapi/components/schemas/MenuSubcategoryListResponse.yaml
@@ -2,7 +2,8 @@ type: object
 properties:
   code:
     description: The status code of the response.
-    type: string
+    type: number
+    format: int32
     nullable: false
   data:
     description: The list of items.

--- a/openapi/components/schemas/ModifierGroupListResponse.yaml
+++ b/openapi/components/schemas/ModifierGroupListResponse.yaml
@@ -2,7 +2,8 @@ type: object
 properties:
   code:
     description: The status code of the response.
-    type: string
+    type: number
+    format: int32
     nullable: false
   message:
     description: The list of modifier groups.

--- a/openapi/components/schemas/ModifierListResponse.yaml
+++ b/openapi/components/schemas/ModifierListResponse.yaml
@@ -2,7 +2,8 @@ type: object
 properties:
   code:
     description: The status code of the response.
-    type: string
+    type: number
+    format: int32
     nullable: false
   message:
     description: The list of modifier groups.


### PR DESCRIPTION
Motivation
----------
We're trying to parse as a string when it returns a number, causing deserialization failures.

Modifications
-------------
Correct the schema to be numeric.

https://centeredge.atlassian.net/browse/ADV-23695
