### PR TITLE
Allow null modifier group name in create modifier (ADV-23940)

### DIFF
--- a/openapi/components/schemas/CreateModifier.yaml
+++ b/openapi/components/schemas/CreateModifier.yaml
@@ -23,7 +23,7 @@ properties:
   modifier_group:
     description: The group to which the modifier belongs.
     type: string
-    nullable: false
+    nullable: true
 required:
   - restaurant_id
   - center_edge


### PR DESCRIPTION
Motivation
---
Truffle updated their endpoint to allow for ModifierGroup to be null when creating a modifier. We need to update our spec to match.

Modifications
---
Set the 'modifier_group' property of the CreateModifier call to be nullable.

https://centeredge.atlassian.net/browse/ADV-23940
