### PR TITLE
Add modifier group ref when creating menu items (PHNX-15705)

### DIFF
--- a/openapi/components/schemas/CreateMenu.yaml
+++ b/openapi/components/schemas/CreateMenu.yaml
@@ -44,10 +44,12 @@ properties:
     description: The CenterEdge id.
     type: string
     nullable: false
+  out_stock:
+    description: If the product is out of stock.
+    $ref: './YesNoValue.yaml'
   is_pizza:
     description: Indicates whether the menu item is a pizza.
-    type: string
-    nullable: false
+    $ref: './YesNoValue.yaml'
   price_type:
     description: always send as "fixed"
     type: string
@@ -56,6 +58,12 @@ properties:
     description: Description of the menu.
     type: string
     nullable: false
+  modifier_group:
+    description: Array of modifier group references in order of display.
+    type: array
+    nullable: false
+    items:
+      $ref: './ModifierGroupReference.yaml'
   serving_size:
     description: Array of serving size objects with name, serving_price, serving_cost, and serving_discount.
     type: array

--- a/openapi/components/schemas/ModifierGroupReference.yaml
+++ b/openapi/components/schemas/ModifierGroupReference.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  Modi_group_id: 
+    description: The ID or CenterEdge ID of the modifier group.
+    type: string
+    nullable: false
+  toppings:
+    $ref: './ToppingType.yaml'
+  defaults:
+    description: IDs or CenterEdge IDs of modifiers in the group which are selected by default. Only applies to Optional topping types.
+    type: array
+    items:
+      type: string
+    nullable: false
+required:
+  - Modi_group_id
+  - toppings
+nullable: false

--- a/openapi/components/schemas/ToppingType.yaml
+++ b/openapi/components/schemas/ToppingType.yaml
@@ -1,0 +1,7 @@
+description: The topping type.
+type: string
+enum:
+  - Required
+  - Optional
+  - Included
+nullable: false

--- a/openapi/components/schemas/YesNoValue.yaml
+++ b/openapi/components/schemas/YesNoValue.yaml
@@ -1,0 +1,5 @@
+type: string
+enum:
+  - "Y"
+  - "N"
+nullable: false


### PR DESCRIPTION
Motivation
----------
Allow menu items to be linked to modifier groups so they prompt for the modifiers.

Modifications
-------------
- Add schemas and properties for modifier group references
- Add Y/N string schema
- Add out_stock flag and change is_pizza to use the new Y/N schema

https://centeredge.atlassian.net/browse/PHNX-15705
