### PR TITLE
Use Modi_grp_id property name (ADV-24121)

### DIFF
--- a/openapi/components/schemas/ModifierGroupReference.yaml
+++ b/openapi/components/schemas/ModifierGroupReference.yaml
@@ -1,6 +1,6 @@
 type: object
 properties:
-  Modi_group_id: 
+  Modi_grp_id: 
     description: The ID or CenterEdge ID of the modifier group.
     type: string
     nullable: false
@@ -13,6 +13,6 @@ properties:
       type: string
     nullable: false
 required:
-  - Modi_group_id
+  - Modi_grp_id
   - toppings
 nullable: false


### PR DESCRIPTION
Motivation
----------
Typo in property name is preventing modifier template referencing.

Modifications
-------------
Use the correct property name.

https://centeredge.atlassian.net/browse/ADV-24121
