### PR TITLE
Add TaxName field to Modifiers (ADV-24494)

### DIFF
--- a/openapi/components/schemas/CreateModifier.yaml
+++ b/openapi/components/schemas/CreateModifier.yaml
@@ -24,6 +24,10 @@ properties:
     description: The group to which the modifier belongs.
     type: string
     nullable: true
+  tax_name:
+    description: Name of the tax group(s) for this modifier.
+    type: string
+    nullable: true
 required:
   - restaurant_id
   - center_edge


### PR DESCRIPTION
Motivaition
---
When syncing modifiers on either single or multi select we are not sending the tax codes. This results in different totals due at the POS v online.

Modifications
---
Added TaxName field to CreateModifier endpoint.

https://centeredge.atlassian.net/browse/ADV-24494
