### PR TITLE
Make menu item description nullable (ADV-24594)

### DIFF
--- a/openapi/components/schemas/CreateMenu.yaml
+++ b/openapi/components/schemas/CreateMenu.yaml
@@ -57,7 +57,7 @@ properties:
   description:
     description: Description of the menu.
     type: string
-    nullable: false
+    nullable: true
   modifier_group:
     description: Array of modifier group references in order of display.
     type: array


### PR DESCRIPTION
Motivation
---
We want to be able to omit the menu item description value during truffle sync.

Modifications
---
Changed menu item description nullable value from false to true.

https://centeredge.atlassian.net/browse/ADV-24594
