### PR TITLE
Make modifier_type nullable (ADV-24573)

### DIFF
--- a/openapi/components/schemas/ModifierBase.yaml
+++ b/openapi/components/schemas/ModifierBase.yaml
@@ -10,6 +10,7 @@ properties:
     example: Ketchup
   modifier_type:
     $ref: ./ModifierType.yaml
+    nullable: true
   quantity:
     description: The quantity of the modifier applied.
     type: number
@@ -18,5 +19,4 @@ properties:
 required:
   - modifier_group_name
   - modifire_name
-  - modifier_type
   - quantity


### PR DESCRIPTION
Motivation
---
We want to be able to send null as the modifier type for truffle orders.

Modifications
---
Altered modifier_type property to be nullable.