### PR TITLE
Make modifier_type nullable (ADV-24857)

### DIFF
--- a/openapi/components/schemas/ModifierBase.yaml
+++ b/openapi/components/schemas/ModifierBase.yaml
@@ -10,7 +10,6 @@ properties:
     example: Ketchup
   modifier_type:
     $ref: ./ModifierType.yaml
-    nullable: true
   quantity:
     description: The quantity of the modifier applied.
     type: number

--- a/openapi/components/schemas/ModifierType.yaml
+++ b/openapi/components/schemas/ModifierType.yaml
@@ -4,4 +4,5 @@ enum:
   - Full
   - Left
   - Right
-default: Full
+default: null
+nullable: true


### PR DESCRIPTION
Motivation
---
We want to be able to send null as the modifier_type value to Truffle.

Modifications
---
Alter ModifierType property to be nullable.

https://centeredge.atlassian.net/browse/ADV-24857
